### PR TITLE
Remove trailing whitespace, add .gitattributes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -55,7 +55,7 @@ IndentWrappedFunctionNames: false
 InsertBraces: false
 InsertNewlineAtEOF: true
 KeepEmptyLines:
-  AtEndOfFile: true 
+  AtEndOfFile: true
   AtStartOfBlock: false
   AtStartOfFile: false
 LineEnding: LF

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md	-whitespace

--- a/Make/common.mk
+++ b/Make/common.mk
@@ -5,7 +5,7 @@ TPATH := $(BUILD_DIR)/$(NAME)
 BPATH := $(BUILD_DIR)/$(NAME)/obj
 
 LIB_OBJS := $(foreach l, $(DEPS), $(BUILD_DIR)/lib/$(l)/$(l).o)
-LDFLAGS := -o $(TPATH)/$(NAME).elf 
+LDFLAGS := -o $(TPATH)/$(NAME).elf
 
 SRC_C := $(shell find . -name '*.c')
 SRC_S := $(shell find . -name '*.s')

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ format $(FILES_C) $(FILES_H):
 clean:
 	rm -rf build
 
-image: 
+image:
 	dd if=/dev/zero of=$(BUILD_DIR)/$(OS).img bs=1M count=10
 
-.PHONY: all clean always image run format 
-
+.PHONY: all clean always image run format

--- a/Markdown/add_acronym.py
+++ b/Markdown/add_acronym.py
@@ -27,14 +27,14 @@ def add_acronym(file_path, acronym, definition=""):
     """Adds a new acronym with an optional definition to the Markdown file."""
     sections = load_acronyms(file_path)
     section_key = acronym[0].upper()  # Determine the correct section (A, B, C, etc.)
-    
+
     # Create a formatted entry
     entry = f"{acronym} - {definition}" if definition else acronym
 
     # Ensure the section exists
     if section_key not in sections:
         sections[section_key] = []
-    
+
     # Avoid duplicates before adding
     if entry not in sections[section_key]:
         sections[section_key].append(entry)
@@ -53,4 +53,3 @@ if __name__ == "__main__":
     definition = " ".join(sys.argv[3:]) if len(sys.argv) > 3 else ""
 
     add_acronym(file_path, acronym, definition)
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,4 +15,3 @@ all:
 	@for dir in $(SRC_DIRS); do make -C $$dir SRC_DIR=$(SRC_DIR) BUILD_DIR=$(BUILD_DIR); done
 
 .PHONY: all
-

--- a/src/example/entry.s
+++ b/src/example/entry.s
@@ -6,18 +6,18 @@
 .global start
 start:
 	.cfi_startproc
-	
+
 .option push
 .option norelax
 	la gp, global_pointer
 .option pop
-	
+
 	/* Reset satp */
 	csrw satp, zero
-	
+
 	/* Setup stack */
 	la sp, stack_top
-	
+
 	/* Clear the BSS section */
 	la t5, bss_start
 	la t6, bss_end
@@ -25,18 +25,17 @@ bss_clear:
 	sd zero, (t5)
 	addi t5, t5, 8
 	bltu t5, t6, bss_clear
-	
+
 	la t0, example_int_handler
 	csrw mepc, t0
-	
+
 	/* Jump to kernel! */
 	jal ra, example_main
 
 halt:
 	wfi
 	j halt
-	
+
 	.cfi_endproc
 
 .end
-

--- a/src/example/linker.ld
+++ b/src/example/linker.ld
@@ -1,7 +1,7 @@
 ENTRY(start);
- 
+
 . = 0x80000000;
- 
+
 SECTIONS {
 	/* Include entry point at start of binary */
 	.text : ALIGN(4K) {


### PR DESCRIPTION
Whitespace cleanup PR + a `.gitattributes` file excluding markdown files from whitespace error checks (because a newline in markdown is two trailing spaces).