### PR TITLE
Added riscv64-elf as a possible prefix toolchain

### DIFF
--- a/CMake/toolchains/riscv64-gcc.cmake
+++ b/CMake/toolchains/riscv64-gcc.cmake
@@ -8,7 +8,7 @@ set(RISCV_GCC_TOOLCHAIN_INCLUDED true)
 
 include(${CMAKE_CURRENT_LIST_DIR}/riscv64-common.cmake)
 
-foreach(PREFIX "riscv64-unknown-linux-elf" "riscv64-linux-gnu" "riscv64-unknown-linux-gnu")
+foreach(PREFIX "riscv64-unknown-linux-elf" "riscv64-linux-gnu" "riscv64-unknown-linux-gnu" "riscv64-elf")
     find_program(PREFIX_TOOLCHAIN_GCC "${PREFIX}-gcc")
     if (PREFIX_TOOLCHAIN_GCC)
         set(DEFAULT_RISCV_TOOLCHAIN_PREFIX "${PREFIX}-")


### PR DESCRIPTION
Didn't work on Manjaro Linux 25.1.0 otherwise