### PR TITLE
Change memory manager to use explicit address space annotation

### DIFF
--- a/include/stdbigos/address.h
+++ b/include/stdbigos/address.h
@@ -1,0 +1,16 @@
+#ifndef _STDBIGOS_ADDRESS_H
+#define _STDBIGOS_ADDRESS_H
+
+#ifdef __clang__
+	#define __noderef __attribute__((noderef))
+	#define __phys    __attribute__((address_space(1), noderef))
+	#define __user    __attribute__((address_space(2), noderef))
+	#define __iomem   __attribute__((address_space(3), noderef))
+#else
+	#define __noderef
+	#define __phys
+	#define __user
+	#define __iomem
+#endif
+
+#endif

--- a/src/kernel/memory_management/include/common_types.h
+++ b/src/kernel/memory_management/include/common_types.h
@@ -1,6 +1,7 @@
 #ifndef KERNEL_MEMORY_MANAGEMENT_COMMON_TYPES
 #define KERNEL_MEMORY_MANAGEMENT_COMMON_TYPES
 
+#include <stdbigos/address.h>
 #include <stdbigos/types.h>
 
 typedef struct {

--- a/src/kernel/memory_management/include/physical_memory/manager.h
+++ b/src/kernel/memory_management/include/physical_memory/manager.h
@@ -2,14 +2,32 @@
 #define BIGOS_KERNEL_MEMORY_MANAGEMENT_PHYSICAL_MEMORY_MANAGER
 
 #include <memory_management/include/common_types.h>
+#include <stdbigos/address.h>
 #include <stdbigos/error.h>
 #include <stdbigos/types.h>
 
-typedef uintptr_t phys_addr_t;
+typedef __phys void* phys_addr_t;
 
-typedef memory_area_t physical_memory_region_t;
+typedef struct {
+	phys_addr_t addr;
+	size_t size;
+} physical_memory_region_t;
 
-static inline void* physical_to_effective([[maybe_unused]] phys_addr_t addr) {
+static inline memory_area_t pmr_to_area(physical_memory_region_t region) {
+	memory_area_t area;
+	area.addr = (uintptr_t)region.addr;
+	area.size = region.size;
+	return area;
+}
+
+static inline physical_memory_region_t area_to_pmr(memory_area_t area) {
+	physical_memory_region_t region;
+	region.addr = (phys_addr_t)area.addr;
+	region.size = area.size;
+	return region;
+}
+
+static inline void* physical_to_effective([[maybe_unused]] __phys void* addr) {
 	return nullptr;
 } // TODO: this is here temporarly
 


### PR DESCRIPTION
It allows clang to warn about unexpected implicit casts.

E.g.
```
void *p;
__phys void * pp = p; // warning
```
will result in a warning.

It also allows to preserve type information and pointer arithmetic semantics that would be expected from non-1-sized types.

It also disallows dereferencing physical pointers.

This introduces also:
`__user` for user-sourced pointers -> we need to validate if the pointer is actually correct. [noderef]
`__iomem` for io-mapped pointers -> probably we need some memory barriers.